### PR TITLE
Update to latest `spec` and `tonic`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utxorpc"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "UTxO RPC SDK"
 repository = "https://github.com/utxorpc/rust-sdk"
@@ -13,8 +13,8 @@ authors = ["Santiago Carmuega <santiago@carmuega.me>"]
 [dependencies]
 thiserror = "1.0.57"
 tokio = "1.35.1"
-tonic = { version = "^0.9", features = ["tls-roots"] }
-utxorpc-spec = { version = "0.3.0" }
+tonic = { version = "^0.11", features = ["tls-roots"] }
+utxorpc-spec = { version = "0.5" }
 
 [dev-dependencies]
 tokio = { version = "1.35.1", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use tonic::{
 };
 
 pub use utxorpc_spec::utxorpc::v1alpha as spec;
-use utxorpc_spec::utxorpc::v1alpha::sync::{BlockRef, DumpHistoryResponse};
+use utxorpc_spec::utxorpc::v1alpha::sync::DumpHistoryResponse;
 
 #[derive(Error, Debug)]
 pub enum Error {


### PR DESCRIPTION
Update to latest `spec` and `tonic` versions. In my manual tests using `cshell`, it seems to be working well against the latest `dolos` source.