### PR TITLE
feat: bump utxorpc-spec to 0.19.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bytes = "1.10.1"
 thiserror = "2.0.12"
 tokio = "1.46.1"
 tonic = { version = "0.12.3", features = ["tls-roots"] }
-utxorpc-spec = { version = "0.18.1" }
+utxorpc-spec = { version = "0.19.0" }
 # utxorpc-spec = { path = "../spec/gen/rust" }
 
 [dev-dependencies]


### PR DESCRIPTION
Bumps `utxorpc-spec` 0.18.1 → 0.19.0 (UTxO RPC spec v0.19.0 line), as part of a coordinated cross-cutting spec bump across the u5c SDKs.

**Verification:** `cargo build` passes against 0.19.0 locally (build-verified).

Part of the u5c-factory `bump-sdk-spec` queue.