### PR TITLE
ci: add minimal build/test pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --workspace --all-targets
+      # Build only the SDK crate. utxorpc-tests is a separate workspace member
+      # (live-server integration suite, currently stale vs the spec) and is
+      # excluded from CI.
+      - run: cargo build -p utxorpc --all-targets
 
   test:
     needs: build
@@ -21,6 +24,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      # utxorpc-tests is an integration suite needing a live server on :50051;
-      # it is compiled by the build job but not executed here.
+      # Only the SDK crate's tests run here; utxorpc-tests is excluded (see build).
       - run: cargo test -p utxorpc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --workspace --all-targets
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # utxorpc-tests is an integration suite needing a live server on :50051;
+      # it is compiled by the build job but not executed here.
+      - run: cargo test -p utxorpc


### PR DESCRIPTION
Adds a CI workflow running build and test jobs on `pull_request` and `push` to `main`, per the UTxO RPC umbrella SDK CI requirements.