### PR TITLE
ci: verify release tag against crate version instead of overwriting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,27 @@
 name: Release
 
 # Conforms to the umbrella SDK release pipeline contract:
-# u5c-factory reference/sdk-pipeline-requirements.md
+# u5c-factory reference/sdk-pipeline.md
 on:
   push:
     tags: ['v*']
 
 jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify tag matches crate version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          MANIFEST=$(sed -nE 's/^version = "(.+)"/\1/p' Cargo.toml | head -1)
+          if [ "$TAG" != "$MANIFEST" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match Cargo.toml version $MANIFEST"
+            exit 1
+          fi
+
   build:
+    needs: verify
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,12 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-
-      - name: Set crate version from tag
-        run: sed -i -E 's/^version = .*/version = "'"${GITHUB_REF_NAME#v}"'"/' Cargo.toml
-
       - name: Publish to crates.io
         env:
-          # --allow-dirty: the version edit above leaves Cargo.toml modified in-tree.
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p utxorpc --allow-dirty
+        run: cargo publish -p utxorpc


### PR DESCRIPTION
## What

rust-sdk’s `release.yml` was merged in #37 **before** the umbrella SDK release pipeline contract settled on **manifest-as-source-of-truth** versioning, so `main` still carries the old tag-derived *overwrite* approach. This brings rust-sdk in line with the other SDKs.

- Adds a **`verify`** job that checks the pushed `v*` tag equals the `Cargo.toml` crate version and **fails fast on mismatch**, before build/test/publish.
- Drops the step that rewrote `Cargo.toml` from the tag; `cargo publish` no longer needs `--allow-dirty`.
- Points the umbrella-contract comment at the renamed `reference/sdk-pipeline.md`.

Pipeline: `verify` → `build` → `test` → `publish`.

## Verification

Workflow YAML syntactically validated only. **Not executed** and the crate **not built** this session — the pipeline can only be exercised by a real tag push.

## Operational prerequisite

The `CARGO_REGISTRY_TOKEN` repository/org secret (a crates.io API token) must exist before the first release.